### PR TITLE
SCRUM-36 AI Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       METEOR_DISABLE_TELEMETRY: "1"
       ENABLE_MONGO_LOG: "false"
       MONGO_URL: "mongodb://127.0.0.1:27017/meteor"
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
       - name: Checkout Repository

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ settings.json
 *.bat
 *.sh
 settings.json
+*.exe

--- a/imports/api/Fhir/fhirMethods.js
+++ b/imports/api/Fhir/fhirMethods.js
@@ -299,4 +299,73 @@ Meteor.methods({
             }
         }
     },
+    async "patient.getSummaryMetrics"(patientID, pageNumber = 1, count = 100) {
+        this.unblock();
+        if (!this.isSimulation) {
+            let { getPatientHealthMetrics } = await import("./Server/FhirUtils.js");
+            try {
+                const [
+                    weightMetrics,
+                    heightMetrics,
+                    systolicMetrics,
+                    diastolicMetrics,
+                    heartRateMetrics,
+                    BMIMetrics,
+                    bodyTempMetrics,
+                    oxygenSaturationMetrics,
+                    hemoglobinMetrics,
+                    hemoglobinA1CMetrics,
+                    ESRMetrics,
+                    glucoseMetrics,
+                    potassiumMetrics,
+                    cholesterolTotalMetrics,
+                    LDLMetrics,
+                    HDLMetrics,
+                    BUNMetrics,
+                    creatinineMetrics
+                ] = await Promise.all([
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_WEIGHT, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_HEIGHT, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_BLOOD_PRESSURE_SYSTOLIC, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_BLOOD_PRESSURE_DIASTOLIC, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_HEART_RATE, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_BMI, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_TEMP, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.BODY_OXYGEN_SATURATION, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.HEMOGLOBIN_HGB, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.HEMOGLOBIN_A1C, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.ERYTHROCYTE_SEDIMENTATION_RT, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.GLUCOSE_SERUM_PLASMA, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.POTASSIUM_SERUM_PLASMA, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.CHOLESTEROL_TOTAL, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.LOW_DENS_LIPOPROTEIN, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.HIGH_DENS_LIPOPROTEIN, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.UREA_NITROGEN_BUN, patientID, pageNumber, count),
+                    getPatientHealthMetrics(LOINC_MAPPING.CREATININE, patientID, pageNumber, count)
+                ]);
+                return {
+                    weightMetrics,
+                    heightMetrics,
+                    systolicMetrics,
+                    diastolicMetrics,
+                    heartRateMetrics,
+                    BMIMetrics,
+                    bodyTempMetrics,
+                    oxygenSaturationMetrics,
+                    hemoglobinMetrics,
+                    hemoglobinA1CMetrics,
+                    ESRMetrics,
+                    glucoseMetrics,
+                    potassiumMetrics,
+                    cholesterolTotalMetrics,
+                    LDLMetrics,
+                    HDLMetrics,
+                    BUNMetrics,
+                    creatinineMetrics
+                };
+            } catch (error) {
+                throw new Meteor.Error("FHIR-Server-Error", error.message);
+            }
+        }
+    }
 });

--- a/imports/api/OpenAI/openaiMethods.js
+++ b/imports/api/OpenAI/openaiMethods.js
@@ -1,0 +1,137 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { OpenAI } from 'openai';
+import { z } from 'zod';
+import { zodResponseFormat } from 'openai/helpers/zod.mjs';
+import { countTokens } from './tokenCounter';
+
+const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY || Meteor.settings.OPENAI_API_KEY
+});
+
+/**
+ * Calls the OpenAI API with a given prompt.
+ *
+ * @param {string} prompt - The prompt to send to OpenAI.
+ * @param {z.ZodType} schema - The Zod schema used to validate the response.
+ * @returns {Promise<Object>} - The parsed data from the OpenAI API response.
+ * @throws {Meteor.Error} - Throws an error if parsing or the API call fails.
+ */
+async function callOpenAI(prompt, schema) {
+    try {
+        const response = await openai.chat.completions.create({
+            model: 'gpt-4o-mini',
+            messages: [
+                {
+                    role: 'system',
+                    content: 'You are a health assistant providing recommended health values.',
+                },
+                {
+                    role: 'user',
+                    content: prompt,
+                },
+            ],
+        response_format: zodResponseFormat(schema, 'response'),
+    });
+
+    const textResponse = response.choices[0].message.content.trim();
+
+    let parsedData;
+    try {
+        parsedData = JSON.parse(textResponse);
+    } catch (parseError) {
+        throw new Meteor.Error('parse-error', 'Failed to parse OpenAI response');
+    }
+
+    return parsedData;
+  } catch (error) {
+        throw new Meteor.Error('openai-error', error.message);
+  }
+}
+
+Meteor.methods({
+    /**
+     * Meteor method to get a range (min and max values) for a given health metric.
+     *
+     * @param {string} metric - The health metric that is being requested.
+     * @param {Object} userData - The user data containing age, gender, weight, and height.
+     * @param {number} userData.age - The age of the user.
+     * @param {string} userData.gender - The gender of the user.
+     * @param {number} userData.weight - The weight of the user in kg.
+     * @param {number} userData.height - The height of the user in cm.
+     * @returns {Object} - An object with a status and the data containing min and max values.
+     */
+    async 'openai.getMinMax'(metric, userData) {
+        // validation
+        check(metric, String);
+        check(userData, {
+            age: Number,
+            gender: String,
+            weight: Number,
+            height: Number,
+        });
+
+        const prompt = `Give me a very generous ${metric} range for a ${userData.age} year-old ${userData.gender} weighing ${userData.weight} kg at ${userData.height} cm. Accomodate for users who may be up to 5.0 out of the range.`
+        const schema = z.object({
+            min: z.number().optional(),
+            max: z.number().optional()
+        });
+
+        const parsedData = await callOpenAI(prompt, schema);
+
+        if (parsedData.min !== undefined && parsedData.max !== undefined) {
+            return {
+                status: 'success',
+                data: {
+                    min: parsedData.min,
+                    max: parsedData.max,
+                },
+            };
+        } else {
+            throw new Meteor.Error(
+                'invalid-data',
+                'Response does not contain both min and max values.'
+            );
+        }
+    },
+
+  /**
+   * Meteor method to get a recommended value for a given health metric.
+   *
+   * @param {string} metric - The health metric that is being requested.
+   * @param {Object} userData - The user data containing age and gender.
+   * @param {number} userData.age - The age of the user.
+   * @param {string} userData.gender - The gender of the user.
+   * @returns {Object} - An object with a status and the data containing the recommended value.
+   */
+    async 'openai.getRecommended'(metric, userData) {
+        // validation
+        check(metric, String);
+        check(userData, {
+            age: Number,
+            gender: String,
+        });
+
+        const prompt = `Give me a recommended ${metric} for a ${userData.age} year-old ${userData.gender} patient.`
+        const schema = z.object({
+            recommended: z.number()
+        })
+        const parsedData = await callOpenAI(prompt, schema);
+
+        if (parsedData.recommended !== undefined) {
+            return {
+                status: 'success',
+                data: {
+                    recommended: parsedData.recommended,
+                },
+            };
+        } else {
+            throw new Meteor.Error(
+                'invalid-data',
+                'Response does not contain a recommended value.'
+            );
+        }
+    },
+});
+
+export { callOpenAI };

--- a/imports/api/OpenAI/tokenCounter.js
+++ b/imports/api/OpenAI/tokenCounter.js
@@ -1,0 +1,10 @@
+import { encode } from "gpt-3-encoder";
+
+/**
+ * Returns the token count for a given text string.
+ * @param {string} text 
+ * @returns {number}
+ */
+export function countTokens(text) {
+    return encode(text).length;
+}

--- a/imports/api/Ozwell/ozwellMethods.js
+++ b/imports/api/Ozwell/ozwellMethods.js
@@ -1,0 +1,240 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { callOpenAI } from '../OpenAI/openaiMethods.js';
+import { z } from 'zod';
+import { countTokens } from '../OpenAI/tokenCounter.js';
+import { logger } from '../Logging/Server/logger-config.js';
+
+async function callOzwell(prompt, schema) {
+    try {
+        const url = 'https://ai.bluehive.com/api/v1/completion';
+        const token = process.env.OZWELL_SECRET_KEY;
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify({
+                prompt,
+                systemMessage: 'You are a health assistant providing the patient with healthcare assistance.',
+                response_format: {
+                    'type': 'json_schema',
+                    'json_schema': {
+                        'name': 'response',
+                        'schema': {
+                            'type': 'object',
+                            'properties': schema
+                        }
+                    }
+                }
+            })
+        });
+
+        if (!response.ok) {
+            throw new Meteor.Error('ozwell-call-failed', `API call failed with status: ${response.status}`)
+        }
+
+        const data = await response.json();
+
+        const textResponse = data.choices?.[0]?.message?.content?.trim();
+        if (!textResponse) {
+            throw new Meteor.Error('ozwell-api-no-response', 'No text response received from Ozwell.')
+        }
+
+        let parsedData;
+        try {
+            parsedData = JSON.parse(textResponse);
+        } catch (parseError) {
+            throw new Meteor.Error('parse-error', 'Failed to parse Ozwell response');
+        }
+
+        return parsedData;
+    } catch (error) {
+        throw new Meteor.Error('ozwell-api-error', error.message);
+    }
+}
+
+/** Hopefully serves as a temporary wrapper for calling our AI tools.
+ *  In the event that Ozwell has an error, it will fallback onto
+ *  OpenAI.
+ * 
+ * @param {*} prompt 
+ * @param {*} schema 
+ * @returns 
+ */
+async function fallbackCall(prompt, schema, fallbackSchema) {
+    try {
+        return await callOzwell(prompt, schema);
+    } catch (ozwellError) {
+        console.error("Ozwell failed, falling back to OpenAI:", ozwellError);
+        return await callOpenAI(prompt, fallbackSchema);
+    }
+}
+
+Meteor.methods({
+    async 'ozwell.getMinMax'(metric, userData) {
+        check(metric, String);
+        check(userData, {
+            age: Number,
+            gender: String,
+            weight: Number,
+            height: Number,
+        });
+
+        const prompt = `
+            Give me a very generous ${metric} range for a ${userData.age} year-old ${userData.gender} weighing ${userData.weight} kg at ${userData.height} cm.`;
+        const schema = {
+            'min': {
+                'type': 'number'
+            },
+            'max': {
+                'type': 'number'
+            }
+        }
+        const fallbackSchema = z.object({
+            min: z.number().optional(),
+            max: z.number().optional()
+        });
+
+        const parsedData = await fallbackCall(prompt, schema, fallbackSchema);
+
+        if (parsedData.min !== undefined && parsedData.max !== undefined) {
+            logger.info(`ozwell.getMinMax called using: ${countTokens(prompt)} tokens`);
+            return {
+                status: 'success',
+                data: {
+                    min: parsedData.min,
+                    max: parsedData.max
+                },
+            };
+        } else {
+            throw new Meteor.Error('invalid-data', 'Response does not contain min and max values.');
+        }
+    },
+
+    async 'ozwell.getRecommended'(metric, userData) {
+        check(metric, String);
+        check(userData, {
+            age: Number,
+            gender: String,
+        });
+
+        const prompt = `
+            Give me a recommended ${metric} for a ${userData.age} year-old ${userData.gender} patient.`;
+        const schema = {
+            'recommended': {
+                'type': 'number'
+            },
+        }
+        const fallbackSchema = z.object({
+            recommended: z.number()
+        })
+
+        const parsedData = await fallbackCall(prompt, schema, fallbackSchema);
+
+        if (parsedData.recommended !== undefined) {
+            logger.info(`ozwell.getRecommended called using: ${countTokens(prompt)} tokens`);
+            return {
+                status: 'success',
+                data: {
+                    recommended: parsedData.recommended
+                },
+            };
+        } else {
+            throw new Meteor.Error('indalid-data', 'Response does not contain a recommended value.')
+        }
+    },
+
+    async 'ozwell.getSummary'(patientID) {
+        const metrics = await Meteor.callAsync('patient.getSummaryMetrics', patientID);
+
+        const latestValue = (metrics) => {
+            if (!metrics || metrics.length === 0) return null;
+            const latest = metrics[0];
+            if (latest.valueQuantities && latest.valueQuantities[0].value) {
+                const val = parseFloat(latest.valueQuantities[0].value);
+                return parseFloat(val.toFixed(3));
+            }
+            return null;
+        };
+
+        const payload = {
+            age: 40, // could be dynamic later
+            gender: 'male', // could be dynamic later
+            weight: latestValue(metrics.weightMetrics),
+            height: latestValue(metrics.heightMetrics),
+            bloodPressure: {
+                systolic: latestValue(metrics.systolicMetrics),
+                diastolic: latestValue(metrics.diastolicMetrics),
+            },
+            heartRate: latestValue(metrics.heartRateMetrics),
+            BMI: latestValue(metrics.BMIMetrics),
+            labResults: {
+                bodyTemp: latestValue(metrics.bodyTempMetrics),
+                oxygenSaturation: latestValue(metrics.oxygenSaturationMetrics),
+                hemoglobin: latestValue(metrics.hemoglobinMetrics),
+                hemoglobinA1C: latestValue(metrics.hemoglobinA1CMetrics),
+                ESR: latestValue(metrics.ESRMetrics),
+                glucose: latestValue(metrics.glucoseMetrics),
+                potassium: latestValue(metrics.potassiumMetrics),
+                cholesterolTotal: latestValue(metrics.cholesterolTotalMetrics),
+                LDL: latestValue(metrics.LDLMetrics),
+                HDL: latestValue(metrics.HDLMetrics),
+                BUN: latestValue(metrics.BUNMetrics),
+                creatinine: latestValue(metrics.creatinineMetrics),
+            },
+        };
+
+        // building the prompt; each field is using the medical abbreviation to minimiaze the amount of tokens used per-call
+        const prompt =
+            `2-4 sentences, speak directly to the patient using "you" and "your" and offer brief advice. Be optimistic. 
+            Wrap important values in <strong> tags.` +
+            `Data: A:${payload.age} G:${payload.gender} W:${payload.weight}kg H:${payload.height}cm BP:${payload.bloodPressure.systolic}/${payload.bloodPressure.diastolic}` +
+            (payload.heartRate ? ` HR:${payload.heartRate}` : '') +
+            (payload.BMI ? ` BMI:${payload.BMI}` : '') +
+            (payload.labResults
+                ? ` L:${[
+                    payload.labResults.bodyTemp && `T${payload.labResults.bodyTemp}`,
+                    payload.labResults.oxygenSaturation && `O${payload.labResults.oxygenSaturation}`,
+                    payload.labResults.hemoglobin && `HGB${payload.labResults.hemoglobin}`,
+                    payload.labResults.hemoglobinA1C && `A1C${payload.labResults.hemoglobinA1C}`,
+                    payload.labResults.ESR && `ESR${payload.labResults.ESR}`,
+                    payload.labResults.glucose && `Glu${payload.labResults.glucose}`,
+                    payload.labResults.potassium && `K${payload.labResults.potassium}`,
+                    payload.labResults.cholesterolTotal && `Chol${payload.labResults.cholesterolTotal}`,
+                    payload.labResults.LDL && `LDL${payload.labResults.LDL}`,
+                    payload.labResults.HDL && `HDL${payload.labResults.HDL}`,
+                    payload.labResults.BUN && `BUN${payload.labResults.BUN}`,
+                    payload.labResults.creatinine && `Cr${payload.labResults.creatinine}`,
+                ]
+                    .filter(Boolean)
+                    .join(',')}`
+                : '') +
+            ` S:`;
+
+        const schema = {
+            'summary': {
+                'type': 'string'
+            }
+        }
+        const fallbackSchema = z.object({
+            summary: z.string()
+        });
+
+        const parsedData = await fallbackCall(prompt, schema, fallbackSchema);
+
+        if (parsedData.summary !== undefined) {
+            logger.info(`ozwell.getSummary called using: ${countTokens(prompt)} tokens`);
+            return {
+                status: 'success',
+                data: {
+                    summary: parsedData.summary
+                }
+            };
+        } else {
+            throw new Meteor.Error('invalid-data', 'Response does not contain a summary.')
+        }
+    }
+})

--- a/imports/ui/pages/DashboardPatient/Components/Summary.jsx
+++ b/imports/ui/pages/DashboardPatient/Components/Summary.jsx
@@ -1,0 +1,39 @@
+import { Meteor } from 'meteor/meteor';
+import React, { useState, useEffect } from 'react';
+
+const Summary = () => {
+    const [summary, setSummary] = useState('');
+
+    useEffect(() => {
+        async function fetchSummary() {
+            try {
+                const patientID = 1
+                const result = await Meteor.callAsync('ozwell.getSummary', patientID);
+
+                if (result && result.data && result.data.summary) {
+                    setSummary(result.data.summary);
+                }
+            } catch (error) {
+                console.error('Error fetching summary.', error);
+                setSummary('Error fetching summary.');
+            }
+        }
+
+        fetchSummary();
+    }, []);
+
+    return (
+        <div className="w-full bg-white rounded-xl shadow-md p-6 mb-6 border border-gray-200">
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3 flex items-center">
+                Your AI Summary 
+                <span className="ml-2 text-yellow-500 text-lg">✨</span>
+            </h2>
+            <div
+                className="text-gray-800 leading-relaxed"
+                dangerouslySetInnerHTML={{ __html: summary }}
+            />
+        </div>
+    );
+};
+
+export default Summary;

--- a/imports/ui/pages/DashboardPatient/DashBoard.jsx
+++ b/imports/ui/pages/DashboardPatient/DashBoard.jsx
@@ -7,6 +7,7 @@ import Widgets from '../../Widgets';
 import { createSwapy, utils } from 'swapy';
 import { isValidToken, refreshToken } from '../../../api/FitBit/auth';
 import { motion, AnimatePresence } from 'framer-motion';
+import Summary from './Components/Summary';
 
 const DashBoard = () => {
     const [widgets, setWidgets] = useState([]);
@@ -99,7 +100,6 @@ const DashBoard = () => {
                 >
                     <Header />
                 </motion.div>
-
                 <div className="p-6 space-y-6 overflow-y-auto">
                     <div className="grid grid-cols-2 sm:grid-cols-3 gap-6 bg-blue-600 text-white rounded-lg shadow-lg p-6">
                         <div>
@@ -121,6 +121,7 @@ const DashBoard = () => {
                             }} />
                         </div>
                     </div>
+                    <Summary />
 
                     <div
                         ref={container}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv-cli": "^8.0.0",
         "fhir-kit-client": "^1.9.2",
         "framer-motion": "^12.4.7",
+        "gpt-3-encoder": "^1.1.4",
         "jose": "^6.0.8",
         "meteor-node-stubs": "^1.2.5",
         "openai": "^4.85.0",
@@ -3584,6 +3585,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/gpt-3-encoder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/gpt-3-encoder/-/gpt-3-encoder-1.1.4.tgz",
+      "integrity": "sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg==",
+      "license": "MIT"
     },
     "node_modules/hammerjs": {
       "version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv-cli": "^8.0.0",
     "fhir-kit-client": "^1.9.2",
     "framer-motion": "^12.4.7",
+    "gpt-3-encoder": "^1.1.4",
     "jose": "^6.0.8",
     "meteor-node-stubs": "^1.2.5",
     "openai": "^4.85.0",

--- a/server/main.js
+++ b/server/main.js
@@ -9,3 +9,5 @@ import "../imports/api/Logging/Server/logs-publications.js"
 import "../imports/startup/Server/accounts-config.js";
 import "../imports/startup/Server/initRoles.js";
 import "../imports/api/User/Server/UserUtils.js"
+import "../imports/api/OpenAI/openaiMethods.js";
+import "../imports/api/Ozwell/ozwellMethods.js";

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,1 +1,3 @@
 import './unit/Fhir.unit.test.js';
+import './unit/OpenAI.unit.test.js';
+import './unit/Ozwell.unit.test.js';

--- a/tests/unit/OpenAI.unit.test.js
+++ b/tests/unit/OpenAI.unit.test.js
@@ -1,0 +1,118 @@
+import { Meteor } from 'meteor/meteor';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import '../../imports/api/OpenAI/openaiMethods.js';
+
+if (Meteor.isServer) {
+    describe('OpenAI', () => {
+        let callAsyncStub;
+
+        beforeEach(() => {
+            callAsyncStub = sinon.stub(Meteor, 'callAsync');
+        });
+
+        afterEach(() => {
+            callAsyncStub.restore();
+        });
+
+        it('openai.getMinMax returns correct data structure', async () => {
+            callAsyncStub.callsFake(async (methodName, metric, userData) => {
+                if (methodName === 'openai.getMinMax') {
+                    return { status: 'success', data: { min: 50, max: 100 } };
+                }
+                throw new Error(`Unknown method: ${methodName}`);
+            });
+
+            const result = await Meteor.callAsync('openai.getMinMax', 'BMI', {
+                age: 40,
+                gender: 'male',
+                weight: 80,
+                height: 180,
+            });
+
+            expect(result.status).to.equal('success');
+            expect(result.data.min).to.equal(50);
+            expect(result.data.max).to.equal(100);
+        });
+
+        it('openai.getMinMax throws error if missing min or max', async () => {
+            callAsyncStub.callsFake(async (methodName, metric, userData) => {
+                if (methodName === 'openai.getMinMax') {  
+                    const error = new Meteor.Error(
+                        'invalid-data',
+                        'Response does not contain both min and max values.'
+                    );
+                    return Promise.reject(error);
+                }
+                throw new Error(`Unknown method: ${methodName}`);
+            });
+
+            try {
+                await Meteor.callAsync('openai.getMinMax', 'BMI', {
+                    age: 40,
+                    gender: 'male',
+                    weight: 80,
+                    height: 180,
+                });
+                expect.fail('Expected method to throw an error');
+            } catch (error) {
+                expect(error.error).to.equal('invalid-data');
+                expect(error.reason).to.equal('Response does not contain both min and max values.');
+            }
+        });
+
+        it('openai.getRecommended returns correct data structure', async () => {
+            callAsyncStub.callsFake(async (methodName, metric, userData) => {
+                if (methodName === 'openai.getRecommended') {
+                    return { status: 'success', data: { recommended: 25 } };
+                }
+                throw new Error(`Unknown method: ${methodName}`);
+            });
+
+            const result = await Meteor.callAsync('openai.getRecommended', 'BMI', {
+                age: 40,
+                gender: 'male',
+            });
+
+            expect(result.status).to.equal('success');
+            expect(result.data.recommended).to.equal(25);
+        });
+
+        it('openai.getRecommended throws error if missing recommended field', async () => {
+            callAsyncStub.callsFake(async (methodName, metric, userData) => {
+                if (methodName === 'openai.getRecommended') {
+                    const error = new Meteor.Error(
+                        'invalid-data',
+                        'Response does not contain a recommended value.'
+                    );
+                    return Promise.reject(error);
+                }
+                throw new Error(`Unknown method: ${methodName}`);
+            });
+
+            try {
+                await Meteor.callAsync('openai.getRecommended', 'BMI', {
+                    age: 40,
+                    gender: 'male',
+                });
+                expect.fail('Expected method to throw an error');
+            } catch (error) {
+                expect(error.error).to.equal('invalid-data');
+                expect(error.reason).to.equal('Response does not contain a recommended value.');
+            }
+        });
+
+        it('throws error if unknown method is called', async () => {
+            callAsyncStub.callsFake(async (methodName) => {
+                throw new Error(`Unknown method: ${methodName}`);
+            });
+
+            try {
+                await Meteor.callAsync('someUnknownMethod');
+                expect.fail('Expected unknown method to throw');
+            } catch (error) {
+                expect(error.message).to.match(/Unknown method: someUnknownMethod/);
+            }
+        });
+    });
+}

--- a/tests/unit/Ozwell.unit.test.js
+++ b/tests/unit/Ozwell.unit.test.js
@@ -1,0 +1,226 @@
+import { Meteor } from 'meteor/meteor';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import '../../imports/api/Ozwell/ozwellMethods.js';
+import * as openaiMethods from '../../imports/api/OpenAI/openaiMethods.js';
+
+if (Meteor.isServer) {
+    describe('OzwellAI', function () {
+        let methodCall;
+        let fetchStub;
+
+        // helper to call meteor functions
+        before(function () {
+            methodCall = (methodName, ...args) =>
+                new Promise((resolve, reject) => {
+                    Meteor.call(methodName, ...args, (err, res) => {
+                        if (err) reject(err);
+                        else resolve(res);
+                    });
+                });
+        });
+
+        beforeEach(function () {
+            fetchStub = sinon.stub(global, 'fetch');
+            sinon.stub(openaiMethods, 'callOpenAI').resolves({ min: 30, max: 40 });
+        });
+
+        afterEach(function () {
+        fetchStub.restore();
+        openaiMethods.callOpenAI.restore();
+        sinon.restore();
+        });
+
+        // ------------------------------------------------------------------------
+        // 1) ozwell.getMinMax
+        // ------------------------------------------------------------------------
+        it('ozwell.getMinMax returns correct data from Ozwell (no fallback)', async function () {
+            // mocking a success response from ozwell
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                    choices: [
+                        {
+                        message: {
+                            content: JSON.stringify({ min: 10, max: 20 }),
+                        },
+                        },
+                    ],
+                }),
+            });
+
+            // calling the stubbed function
+            const result = await methodCall('ozwell.getMinMax', 'BMI', {
+                age: 40,
+                gender: 'male',
+                weight: 80,
+                height: 180,
+            });
+
+            // these are to check if the output from the tests are expected
+            expect(result.status).to.equal('success')
+            expect(result.data.min).to.equal(10)
+            expect(result.data.max).to.equal(20)
+
+            // the call didnt fail, so dont call openai
+            expect(openaiMethods.callOpenAI.called).to.be.false;
+        });
+
+        it('ozwell.getMinMax throws error if missing min or max', async function () {
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                choices: [
+                    { message: { content: JSON.stringify({ min: 10 }) } },
+                ],
+                }),
+            })
+
+            try {
+                await methodCall('ozwell.getMinMax', 'BMI', {
+                age: 40,
+                gender: 'male',
+                weight: 80,
+                height: 180,
+                });
+                expect.fail('Expected method to throw an error');
+            } catch (err) {
+                expect(err.error).to.equal('invalid-data');
+            }
+        });
+
+        // ------------------------------------------------------------------------
+        // 2) ozwell.getRecommended
+        // ------------------------------------------------------------------------
+        it('ozwell.getRecommended returns data from Ozwell (no fallback)', async function () {
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                choices: [
+                    {
+                    message: {
+                        content: JSON.stringify({ recommended: 77 }),
+                    },
+                    },
+                ],
+                }),
+            })
+
+            const result = await methodCall('ozwell.getRecommended', 'BMI', {
+                age: 40,
+                gender: 'male',
+            })
+
+            expect(result.status).to.equal('success');
+            expect(result.data.recommended).to.equal(77);
+            expect(openaiMethods.callOpenAI.called).to.be.false;
+        });
+
+        it('ozwell.getRecommended throws if missing recommended', async function () {
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                choices: [
+                    { message: { content: JSON.stringify({}) } },
+                ],
+                }),
+            })
+
+            try {
+                await methodCall('ozwell.getRecommended', 'BMI', {
+                age: 40,
+                gender: 'male',
+                });
+                expect.fail('Expected method to throw');
+            } catch (err) {
+                expect(err.error).to.equal('indalid-data');
+            }
+        });
+
+        // ------------------------------------------------------------------------
+        // 3) ozwell.getSummary
+        // ------------------------------------------------------------------------
+        it('ozwell.getSummary returns summary from Ozwell (no fallback)', async function () {
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                choices: [
+                    {
+                    message: {
+                        content: JSON.stringify({ summary: 'test' }),
+                    },
+                    },
+                ],
+                }),
+            });
+
+            sinon.stub(Meteor, 'callAsync')
+            .withArgs('patient.getSummaryMetrics', 1).resolves({
+                weightMetrics: [{ valueQuantities: [{ value: 80 }] }],
+                heightMetrics: [{ valueQuantities: [{ value: 180 }] }],
+                systolicMetrics: [{ valueQuantities: [{ value: 120 }] }],
+                diastolicMetrics: [{ valueQuantities: [{ value: 80 }] }],
+                heartRateMetrics: [],
+                BMIMetrics: [],
+                bodyTempMetrics: [],
+                oxygenSaturationMetrics: [],
+                hemoglobinMetrics: [],
+                hemoglobinA1CMetrics: [],
+                ESRMetrics: [],
+                glucoseMetrics: [],
+                potassiumMetrics: [],
+                cholesterolTotalMetrics: [],
+                LDLMetrics: [],
+                HDLMetrics: [],
+                BUNMetrics: [],
+                creatinineMetrics: [],
+            });
+
+            const result = await methodCall('ozwell.getSummary', 1);
+            expect(result.status).to.equal('success');
+            expect(result.data.summary).to.equal('test');
+            expect(openaiMethods.callOpenAI.called).to.be.false;
+        });
+
+        it('ozwell.getSummary throws if missing summary', async function () {
+            fetchStub.resolves({
+                ok: true,
+                json: async () => ({
+                    choices: [
+                        { message: { content: JSON.stringify({}) } },
+                    ],
+                }),
+            });
+
+            sinon.stub(Meteor, 'callAsync')
+            .withArgs('patient.getSummaryMetrics', 1).resolves({
+                weightMetrics: [{ valueQuantities: [{ value: 80 }] }],
+                heightMetrics: [{ valueQuantities: [{ value: 180 }] }],
+                systolicMetrics: [{ valueQuantities: [{ value: 120 }] }],
+                diastolicMetrics: [{ valueQuantities: [{ value: 80 }] }],
+                heartRateMetrics: [{ valueQuantities: [{ value: 70 }] }],
+                BMIMetrics: [{ valueQuantities: [{ value: 24 }] }],
+                bodyTempMetrics: [],
+                oxygenSaturationMetrics: [],
+                hemoglobinMetrics: [],
+                hemoglobinA1CMetrics: [],
+                ESRMetrics: [],
+                glucoseMetrics: [],
+                potassiumMetrics: [],
+                cholesterolTotalMetrics: [],
+                LDLMetrics: [],
+                HDLMetrics: [],
+                BUNMetrics: [],
+                creatinineMetrics: [],
+            });
+
+            try {
+                await methodCall('ozwell.getSummary', 1);
+                expect.fail('Expected method to throw');
+            } catch (err) {
+                expect(err.error).to.equal('invalid-data');
+                expect(err.reason).to.match(/does not contain a summary/i);
+            }
+        });
+    });
+}


### PR DESCRIPTION
Completed refactor for OpenAI and Ozwell. Almost everything acts the same as before, but with a few optimizations. 
1. Data stays in the server instead of being transferred from server --> client --> server
2. Added bold for important labs in the summary

To use, call `await Meteor.callAsync("ozwell.getSummary", patientID);`. Previously, the data was sent (unnecessarily) to the client and then back to the server, so this refactor simplifies it for developers. The same change will be made to ozwell.getMinMax and ozwell.getRecommended in the future once they are of use.